### PR TITLE
解决 #50 和 #77 下 Web 的内存泄露

### DIFF
--- a/cnocr/cn_ocr.py
+++ b/cnocr/cn_ocr.py
@@ -312,7 +312,9 @@ class CnOcr(object):
     def _predict(self, sample):
         mod = self._mod
         mod.forward(sample)
-        prob = mod.get_outputs()[0].asnumpy()
+        prob = mod.get_outputs()[0]
+        mx.nd.waitall()
+        prob = prob.asnumpy()
         return prob
 
     def _gen_line_pred_chars(self, line_prob, img_width, max_img_width):


### PR DESCRIPTION
mx 的 Python 包装中计算图是异步的, 只会把操作推到后端的队列里, 直到遇到求值操作或者计算完毕, 才会有值确定下来. 

但是这个方案多线程时经常会出现问题, 一般来讲在合适的地方加上`mx.nd.waitall()`就能解决. 