### PR TITLE
fix gpu config

### DIFF
--- a/docs/examples/train_config_gpu.json
+++ b/docs/examples/train_config_gpu.json
@@ -25,6 +25,6 @@
     "precision": 16,
     "limit_train_batches": 1.0,
     "limit_val_batches": 1.0,
-    "pl_checkpoint_monitor": "complete_match_epoch",
+    "pl_checkpoint_monitor": "val-complete_match-epoch",
     "pl_checkpoint_mode": "max"
 }


### PR DESCRIPTION
应该是GPU的忘了改了吧，metric里面已经没有"complete_match_epoch"，导致报如下错误
```
lightning_fabric.utilities.exceptions.MisconfigurationException: `ModelCheckpoint(monitor='complete_match_epoch')` could not find the monitored key in the returned metrics:
```
改成和cpu的一致。